### PR TITLE
Add CBO capacity status feature

### DIFF
--- a/app/controllers/capacity_controller.rb
+++ b/app/controllers/capacity_controller.rb
@@ -1,15 +1,25 @@
 class CapacityController < ApplicationController
   before_action :require_fhir_client
 
-  VALID_STATUSES = %w[capacity at-capacity has-waitlist].freeze
+  VALID_STATUSES = %w[capacity at-capacity has-waitlist assessment-required].freeze
   CAPACITY_EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
   TEMPORARY_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
 
-  # Map UI statuses to the codes defined in SDOHCC-CodeSystemTemporaryCodes
+  # SDOHCC-ExtensionHealthcareServiceCapacityStatus is a complex extension: the
+  # code goes on a capacityStatus sub-extension (1..1) and a value on the outer
+  # extension is prohibited (Extension.value[x] is 0..0).
+  CAPACITY_STATUS_SUB_EXTENSION_URL = "capacityStatus".freeze
+
+  # Map UI statuses to the codes defined in SDOHCC-CodeSystemTemporaryCodes.
+  # That CodeSystem defines only no-capacity, capacity, waitlist and
+  # additional-assessment-required -- "no-capacity-has-waitlist" was never one
+  # of them, and referral clients bound to SDOHCC-ValueSetCapacityStatus will
+  # not recognize it.
   STATUS_TO_CODE = {
     "capacity" => "capacity",
     "at-capacity" => "no-capacity",
-    "has-waitlist" => "no-capacity-has-waitlist",
+    "has-waitlist" => "waitlist",
+    "assessment-required" => "additional-assessment-required",
   }.freeze
 
   def update
@@ -56,14 +66,19 @@ class CapacityController < ApplicationController
       service.extension.reject! { |e| e.url == CAPACITY_EXTENSION_URL }
       service.extension << FHIR::Extension.new(
         url: CAPACITY_EXTENSION_URL,
-        valueCodeableConcept: FHIR::CodeableConcept.new(
-          coding: [
-            FHIR::Coding.new(
-              system: TEMPORARY_CODE_SYSTEM,
-              code: code
+        extension: [
+          FHIR::Extension.new(
+            url: CAPACITY_STATUS_SUB_EXTENSION_URL,
+            valueCodeableConcept: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: TEMPORARY_CODE_SYSTEM,
+                  code: code
+                )
+              ]
             )
-          ]
-        )
+          )
+        ]
       )
 
       if is_new

--- a/app/controllers/capacity_controller.rb
+++ b/app/controllers/capacity_controller.rb
@@ -1,0 +1,82 @@
+class CapacityController < ApplicationController
+  before_action :require_fhir_client
+
+  VALID_STATUSES = %w[capacity at-capacity has-waitlist].freeze
+  CAPACITY_EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
+  TEMPORARY_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+
+  # Map UI statuses to the codes defined in SDOHCC-CodeSystemTemporaryCodes
+  STATUS_TO_CODE = {
+    "capacity" => "capacity",
+    "at-capacity" => "no-capacity",
+    "has-waitlist" => "no-capacity-has-waitlist",
+  }.freeze
+
+  def update
+    status = params[:capacity_status]
+    if VALID_STATUSES.include?(status)
+      save_capacity_status(status)
+      update_fhir_healthcare_service(status)
+      flash[:success] = "Capacity status set to #{status.titleize}"
+    else
+      flash[:error] = "Invalid capacity status"
+    end
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def update_fhir_healthcare_service(status)
+    client = get_fhir_client
+    org_id = get_my_org_id
+    code = STATUS_TO_CODE.fetch(status)
+    Rails.logger.info("Attempting to update FHIR HealthcareService: client=#{!!client}, org_id=#{org_id}")
+    return unless client && org_id
+
+    begin
+      # Search for a HealthcareService provided by this organization
+      Rails.logger.info("Searching for HealthcareService with organization=#{org_id}")
+      bundle = client.search(FHIR::HealthcareService, search: { parameters: { organization: org_id } }).resource
+      service = bundle&.entry&.map(&:resource)&.compact&.first
+      is_new = service.nil?
+
+      if is_new
+        # No HealthcareService exists yet for this organization; create one so
+        # referral clients can discover our capacity status.
+        Rails.logger.info("No HealthcareService found for organization #{org_id}, creating one")
+        service = FHIR::HealthcareService.new(
+          active: true,
+          providedBy: { reference: "Organization/#{org_id}" },
+          name: "Services provided by Organization/#{org_id}"
+        )
+      end
+
+      # Update or create the capacity extension
+      service.extension ||= []
+      service.extension.reject! { |e| e.url == CAPACITY_EXTENSION_URL }
+      service.extension << FHIR::Extension.new(
+        url: CAPACITY_EXTENSION_URL,
+        valueCodeableConcept: FHIR::CodeableConcept.new(
+          coding: [
+            FHIR::Coding.new(
+              system: TEMPORARY_CODE_SYSTEM,
+              code: code
+            )
+          ]
+        )
+      )
+
+      if is_new
+        created = client.create(service)
+        Rails.logger.info("Successfully created HealthcareService with capacity #{code}: #{created&.resource&.id || created.inspect}")
+      else
+        client.update(service, service.id)
+        Rails.logger.info("Successfully updated HealthcareService #{service.id} capacity to #{code}")
+      end
+    rescue => e
+      Rails.logger.error("Failed to update FHIR HealthcareService capacity: #{e.full_message}")
+      Rails.logger.error(e.backtrace.join("\n"))
+      # Don't fail the entire request if FHIR update fails
+    end
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -67,6 +67,10 @@ class TasksController < ApplicationController
       @active_tasks = result["active"] || []
       @completed_tasks = result["completed"] || []
       @cancelled_tasks = result["cancelled"] || []
+      if get_capacity_status == "at-capacity"
+        newly_rejected, @active_tasks = auto_reject_at_capacity(@active_tasks)
+        @cancelled_tasks = newly_rejected + @cancelled_tasks
+      end
 
       new_tasks_list = Rails.cache.read(tasks_key) || []
       # check if any active tasks have changed status
@@ -119,5 +123,36 @@ class TasksController < ApplicationController
     procedure.performedDateTime = Time.now.utc.strftime("%Y-%m-%d")
 
     get_fhir_client.create(procedure).resource
+  end
+
+  def auto_reject_at_capacity(tasks)
+    client = get_fhir_client
+    at_capacity_since = get_capacity_status_set_at
+    rejected, remaining = [], []
+    tasks.each do |task|
+      if task.status == "requested" && requested_after?(task, at_capacity_since)
+        fhir_task = task.fhir_resource
+        fhir_task.status = "rejected"
+        fhir_task.statusReason = { text: "Rejected - at capacity" }
+        client.update(fhir_task, fhir_task.id)
+        rejected << Task.new(fhir_task, client)
+      else
+        remaining << task
+      end
+    end
+    [rejected, remaining]
+  end
+
+  # Only tasks requested AFTER the organization went to capacity are
+  # auto-rejected; requests already received keep their place in the queue.
+  def requested_after?(task, at_capacity_since)
+    return false if at_capacity_since.nil?
+
+    authored_on = task.fhir_resource&.authoredOn
+    return false if authored_on.blank?
+
+    Time.parse(authored_on) > at_capacity_since
+  rescue ArgumentError
+    false
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -38,6 +38,19 @@ module SessionsHelper
     session[:org_id]
   end
 
+  def save_capacity_status(status)
+    session[:capacity_status] = status
+    session[:capacity_status_set_at] = Time.now.utc.iso8601
+  end
+
+  def get_capacity_status
+    session[:capacity_status] || "capacity"
+  end
+
+  def get_capacity_status_set_at
+    session[:capacity_status_set_at] && Time.parse(session[:capacity_status_set_at])
+  end
+
   def save_user_id(user_id)
     session[:user_id] = user_id
   end

--- a/app/views/dashboard/_capacity_status_toggle.html.erb
+++ b/app/views/dashboard/_capacity_status_toggle.html.erb
@@ -1,0 +1,7 @@
+<div class="btn-group capacity-status-toggle" role="group" aria-label="Capacity Status">
+  <span class="me-2 text-muted small align-self-center">Capacity Status</span>
+  <% [["capacity", "Capacity Available", "success"], ["at-capacity", "At Capacity", "danger"], ["has-waitlist", "Has Waitlist", "warning"]].each do |value, label, style| %>
+    <%= button_to label, capacity_status_path, params: { capacity_status: value }, method: :post,
+          class: "btn btn-sm #{get_capacity_status == value ? "btn-#{style}" : "btn-outline-#{style}"}" %>
+  <% end %>
+</div>

--- a/app/views/dashboard/_capacity_status_toggle.html.erb
+++ b/app/views/dashboard/_capacity_status_toggle.html.erb
@@ -1,6 +1,9 @@
 <div class="btn-group capacity-status-toggle" role="group" aria-label="Capacity Status">
   <span class="me-2 text-muted small align-self-center">Capacity Status</span>
-  <% [["capacity", "Capacity Available", "success"], ["at-capacity", "At Capacity", "danger"], ["has-waitlist", "Has Waitlist", "warning"]].each do |value, label, style| %>
+  <% [["capacity", "Capacity Available", "success"],
+      ["at-capacity", "At Capacity", "danger"],
+      ["has-waitlist", "Has Waitlist", "warning"],
+      ["assessment-required", "Additional Assessment Required", "info"]].each do |value, label, style| %>
     <%= button_to label, capacity_status_path, params: { capacity_status: value }, method: :post,
           class: "btn btn-sm #{get_capacity_status == value ? "btn-#{style}" : "btn-outline-#{style}"}" %>
   <% end %>

--- a/app/views/dashboard/_main_header.html.erb
+++ b/app/views/dashboard/_main_header.html.erb
@@ -18,6 +18,9 @@
         </ul>
       </div>
       <div class="col-auto">
+        <%= render "capacity_status_toggle" %>
+      </div>
+      <div class="col-auto">
         <%= render "user_info" %>
       </div>
     </div>

--- a/app/views/dashboard/_tasks_table.html.erb
+++ b/app/views/dashboard/_tasks_table.html.erb
@@ -50,7 +50,10 @@
                 <% if status == "completed" %>
                   <span class="bi bi-check-lg text-success"></span> Completed
                 <% end %>
-                <% if status == "cancelled" || status == "rejected" %>
+                <% if status == "rejected" && referral.status_reason == "Rejected - at capacity" %>
+                  <span class="badge bg-danger">Rejected — At Capacity</span>
+                  <span class="badge bg-light text-danger border border-danger ms-1">auto-rejected</span>
+                <% elsif status == "cancelled" || status == "rejected" %>
                   <span class="bi bi-x-circle text-danger"></span><%= status.capitalize %>
                 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   get "dashboard", to: "dashboard#index"
   get "tasks/:id/:status", to: "tasks#update_task"
   get "poll_tasks", to: "tasks#poll_tasks"
+  post "/capacity_status", to: "capacity#update", as: :capacity_status
 end


### PR DESCRIPTION
Lets a CBO declare capacity status from the dashboard header, synced to the FHIR HealthcareService capacity extension. Incoming Task requests received while At Capacity are auto-rejected on poll.