### PR TITLE
Read capacity status from FHIR instead of the session (CFRID-944)

### DIFF
--- a/app/controllers/capacity_controller.rb
+++ b/app/controllers/capacity_controller.rb
@@ -1,97 +1,24 @@
 class CapacityController < ApplicationController
   before_action :require_fhir_client
 
-  VALID_STATUSES = %w[capacity at-capacity has-waitlist assessment-required].freeze
-  CAPACITY_EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
-  TEMPORARY_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
-
-  # SDOHCC-ExtensionHealthcareServiceCapacityStatus is a complex extension: the
-  # code goes on a capacityStatus sub-extension (1..1) and a value on the outer
-  # extension is prohibited (Extension.value[x] is 0..0).
-  CAPACITY_STATUS_SUB_EXTENSION_URL = "capacityStatus".freeze
-
-  # Map UI statuses to the codes defined in SDOHCC-CodeSystemTemporaryCodes.
-  # That CodeSystem defines only no-capacity, capacity, waitlist and
-  # additional-assessment-required -- "no-capacity-has-waitlist" was never one
-  # of them, and referral clients bound to SDOHCC-ValueSetCapacityStatus will
-  # not recognize it.
-  STATUS_TO_CODE = {
-    "capacity" => "capacity",
-    "at-capacity" => "no-capacity",
-    "has-waitlist" => "waitlist",
-    "assessment-required" => "additional-assessment-required",
-  }.freeze
-
+  # POST /capacity_status
+  #
+  # Writes the selection straight through to the organization's FHIR
+  # HealthcareService; there is no session copy to keep in sync.
   def update
     status = params[:capacity_status]
-    if VALID_STATUSES.include?(status)
-      save_capacity_status(status)
-      update_fhir_healthcare_service(status)
-      flash[:success] = "Capacity status set to #{status.titleize}"
-    else
+
+    unless CapacityStatus.valid?(status)
       flash[:error] = "Invalid capacity status"
+      return redirect_to dashboard_path
     end
+
+    if save_capacity_status(status)
+      flash[:success] = "Capacity status set to #{CapacityStatus.label_for(status)}"
+    else
+      flash[:error] = "Capacity status could not be saved to the FHIR server. Check the server connection and try again."
+    end
+
     redirect_to dashboard_path
-  end
-
-  private
-
-  def update_fhir_healthcare_service(status)
-    client = get_fhir_client
-    org_id = get_my_org_id
-    code = STATUS_TO_CODE.fetch(status)
-    Rails.logger.info("Attempting to update FHIR HealthcareService: client=#{!!client}, org_id=#{org_id}")
-    return unless client && org_id
-
-    begin
-      # Search for a HealthcareService provided by this organization
-      Rails.logger.info("Searching for HealthcareService with organization=#{org_id}")
-      bundle = client.search(FHIR::HealthcareService, search: { parameters: { organization: org_id } }).resource
-      service = bundle&.entry&.map(&:resource)&.compact&.first
-      is_new = service.nil?
-
-      if is_new
-        # No HealthcareService exists yet for this organization; create one so
-        # referral clients can discover our capacity status.
-        Rails.logger.info("No HealthcareService found for organization #{org_id}, creating one")
-        service = FHIR::HealthcareService.new(
-          active: true,
-          providedBy: { reference: "Organization/#{org_id}" },
-          name: "Services provided by Organization/#{org_id}"
-        )
-      end
-
-      # Update or create the capacity extension
-      service.extension ||= []
-      service.extension.reject! { |e| e.url == CAPACITY_EXTENSION_URL }
-      service.extension << FHIR::Extension.new(
-        url: CAPACITY_EXTENSION_URL,
-        extension: [
-          FHIR::Extension.new(
-            url: CAPACITY_STATUS_SUB_EXTENSION_URL,
-            valueCodeableConcept: FHIR::CodeableConcept.new(
-              coding: [
-                FHIR::Coding.new(
-                  system: TEMPORARY_CODE_SYSTEM,
-                  code: code
-                )
-              ]
-            )
-          )
-        ]
-      )
-
-      if is_new
-        created = client.create(service)
-        Rails.logger.info("Successfully created HealthcareService with capacity #{code}: #{created&.resource&.id || created.inspect}")
-      else
-        client.update(service, service.id)
-        Rails.logger.info("Successfully updated HealthcareService #{service.id} capacity to #{code}")
-      end
-    rescue => e
-      Rails.logger.error("Failed to update FHIR HealthcareService capacity: #{e.full_message}")
-      Rails.logger.error(e.backtrace.join("\n"))
-      # Don't fail the entire request if FHIR update fails
-    end
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -67,7 +67,9 @@ class TasksController < ApplicationController
       @active_tasks = result["active"] || []
       @completed_tasks = result["completed"] || []
       @cancelled_tasks = result["cancelled"] || []
-      if get_capacity_status == "at-capacity"
+      # Read from the HealthcareService, not the session, so auto-rejection keeps
+      # working across new sessions, restarts and other users of the same CBO.
+      if get_capacity_status == CapacityStatus::AT_CAPACITY
         newly_rejected, @active_tasks = auto_reject_at_capacity(@active_tasks)
         @cancelled_tasks = newly_rejected + @cancelled_tasks
       end
@@ -145,6 +147,8 @@ class TasksController < ApplicationController
 
   # Only tasks requested AFTER the organization went to capacity are
   # auto-rejected; requests already received keep their place in the queue.
+  # The cutoff is HealthcareService.meta.lastUpdated -- i.e. when the capacity
+  # status was last written to FHIR -- so it is not lost with the session.
   def requested_after?(task, at_capacity_since)
     return false if at_capacity_since.nil?
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -38,17 +38,23 @@ module SessionsHelper
     session[:org_id]
   end
 
+  # Capacity status lives on the organization's FHIR HealthcareService, not in
+  # the session, so it survives new sessions/restarts and is shared by everyone
+  # signed in as the same CBO (CFRID-944).
+  def capacity_status
+    @capacity_status ||= CapacityStatus.new(get_fhir_client, get_my_org_id)
+  end
+
   def save_capacity_status(status)
-    session[:capacity_status] = status
-    session[:capacity_status_set_at] = Time.now.utc.iso8601
+    capacity_status.save(status)
   end
 
   def get_capacity_status
-    session[:capacity_status] || "capacity"
+    capacity_status.status
   end
 
   def get_capacity_status_set_at
-    session[:capacity_status_set_at] && Time.parse(session[:capacity_status_set_at])
+    capacity_status.updated_at
   end
 
   def save_user_id(user_id)

--- a/app/models/capacity_status.rb
+++ b/app/models/capacity_status.rb
@@ -1,0 +1,204 @@
+# Reads and writes the CBO's capacity status.
+#
+# The organization's FHIR HealthcareService resource -- not the Rails session --
+# is the source of truth. Keeping it in the session meant the dashboard toggle
+# and the auto-rejection rules silently reset to "Capacity Available" on every
+# new session, app restart or second user of the same CBO, even though the
+# HealthcareService still said otherwise (CFRID-944).
+class CapacityStatus
+  EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
+  CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+
+  # SDOHCC-ExtensionHealthcareServiceCapacityStatus is a complex extension: the
+  # code goes on a capacityStatus sub-extension (1..1) and a value on the outer
+  # extension is prohibited (Extension.value[x] is 0..0).
+  SUB_EXTENSION_URL = "capacityStatus".freeze
+
+  # Single source of truth for the UI toggle and the FHIR codes. The codes are
+  # the ones defined in SDOHCC-CodeSystemTemporaryCodes -- referral clients bound
+  # to SDOHCC-ValueSetCapacityStatus will not recognize anything else.
+  STATUSES = {
+    "capacity" => { label: "Capacity Available", style: "success", code: "capacity" },
+    "at-capacity" => { label: "At Capacity", style: "danger", code: "no-capacity" },
+    "has-waitlist" => { label: "Has Waitlist", style: "warning", code: "waitlist" },
+    "assessment-required" => { label: "Additional Assessment Required", style: "info", code: "additional-assessment-required" },
+  }.freeze
+
+  DEFAULT_STATUS = "capacity".freeze
+  AT_CAPACITY = "at-capacity".freeze
+
+  STATUS_TO_CODE = STATUSES.each_with_object({}) { |(status, meta), acc| acc[status] = meta[:code] }.freeze
+
+  # Inverse map, plus tolerance for "no-capacity-has-waitlist", which an earlier
+  # build of this feature wrote before the codes were corrected.
+  CODE_TO_STATUS = STATUS_TO_CODE.invert.merge("no-capacity-has-waitlist" => "has-waitlist").freeze
+
+  # Short TTL so the dashboard poll (every ~8s) does not hit the FHIR server on
+  # every request, while a change made elsewhere still surfaces quickly. Our own
+  # writes prime the cache directly, so they are visible immediately.
+  CACHE_TTL = 30.seconds
+
+  def self.valid?(status)
+    STATUSES.key?(status)
+  end
+
+  def self.label_for(status)
+    STATUSES.dig(status, :label) || status.to_s
+  end
+
+  def self.cache_key(org_id)
+    "capacity_status_#{org_id}"
+  end
+
+  def initialize(client, org_id)
+    @client = client
+    @org_id = org_id
+  end
+
+  # The persisted status, e.g. "at-capacity". Falls back to DEFAULT_STATUS when
+  # the org has no HealthcareService, no capacity extension, or the server is
+  # unreachable.
+  def status
+    current["status"]
+  end
+
+  # When the status was last written, taken from HealthcareService.meta.lastUpdated
+  # so that it survives sessions. Used to keep auto-rejection non-retroactive.
+  def updated_at
+    current["updated_at"]
+  end
+
+  # Persists the status on the organization's HealthcareService, creating the
+  # resource when the org does not have one yet. Returns true on success.
+  def save(status)
+    return false unless usable?
+    return false unless self.class.valid?(status)
+
+    code = STATUS_TO_CODE.fetch(status)
+    service = find_service
+    is_new = service.nil?
+
+    if is_new
+      # No HealthcareService exists yet for this organization; create one so
+      # referral clients can discover our capacity status.
+      Rails.logger.info("No HealthcareService found for organization #{@org_id}, creating one")
+      service = FHIR::HealthcareService.new(
+        active: true,
+        providedBy: { reference: "Organization/#{@org_id}" },
+        name: "Services provided by Organization/#{@org_id}",
+      )
+    end
+
+    apply_extension(service, code)
+
+    saved = is_new ? @client.create(service) : @client.update(service, service.id)
+    Rails.logger.info("Successfully #{is_new ? "created" : "updated"} HealthcareService #{saved&.resource&.id || service.id} capacity to #{code}")
+
+    write_cache(status, timestamp_from(saved) || Time.now.utc)
+    true
+  rescue => e
+    Rails.logger.error("Failed to update FHIR HealthcareService capacity: #{e.full_message}")
+    expire_cache
+    false
+  end
+
+  def expire_cache
+    Rails.cache.delete(self.class.cache_key(@org_id)) if @org_id.present?
+  end
+
+  private
+
+  def usable?
+    @client.present? && @org_id.present?
+  end
+
+  def current
+    return default_reading unless usable?
+
+    Rails.cache.fetch(self.class.cache_key(@org_id), expires_in: CACHE_TTL) do
+      read_from_fhir
+    end
+  rescue => e
+    Rails.logger.error("Failed to read capacity status from FHIR: #{e.full_message}")
+    default_reading
+  end
+
+  def read_from_fhir
+    Rails.logger.info("Reading capacity status from HealthcareService for organization #{@org_id}")
+    service = find_service
+    return default_reading if service.nil?
+
+    code = extract_code(service)
+    status = CODE_TO_STATUS[code]
+    if code.present? && status.nil?
+      Rails.logger.warn("Unrecognized capacity status code '#{code}' on HealthcareService/#{service.id}; falling back to #{DEFAULT_STATUS}")
+    end
+
+    {
+      "status" => status || DEFAULT_STATUS,
+      "updated_at" => parse_time(service.meta && service.meta.lastUpdated),
+    }
+  end
+
+  def find_service
+    bundle = @client.search(FHIR::HealthcareService, search: { parameters: { organization: @org_id } }).resource
+    bundle&.entry&.map(&:resource)&.compact&.first
+  end
+
+  def extract_code(service)
+    outer = Array(service.extension).find { |e| e.url == EXTENSION_URL }
+    return nil if outer.nil?
+
+    sub = Array(outer.extension).find { |e| e.url == SUB_EXTENSION_URL }
+    # Older builds wrote the CodeableConcept on the outer extension; read either.
+    coding = Array(sub&.valueCodeableConcept&.coding)
+    coding = Array(outer.valueCodeableConcept&.coding) if coding.empty?
+
+    (coding.find { |c| c.system == CODE_SYSTEM } || coding.first)&.code
+  end
+
+  def apply_extension(service, code)
+    service.extension ||= []
+    service.extension.reject! { |e| e.url == EXTENSION_URL }
+    service.extension << FHIR::Extension.new(
+      url: EXTENSION_URL,
+      extension: [
+        FHIR::Extension.new(
+          url: SUB_EXTENSION_URL,
+          valueCodeableConcept: FHIR::CodeableConcept.new(
+            coding: [FHIR::Coding.new(system: CODE_SYSTEM, code: code)],
+          ),
+        ),
+      ],
+    )
+  end
+
+  def write_cache(status, updated_at)
+    return if @org_id.blank?
+
+    Rails.cache.write(
+      self.class.cache_key(@org_id),
+      { "status" => status, "updated_at" => updated_at },
+      expires_in: CACHE_TTL,
+    )
+  end
+
+  def timestamp_from(reply)
+    resource = reply&.resource
+    return nil unless resource.is_a?(FHIR::HealthcareService)
+
+    parse_time(resource.meta && resource.meta.lastUpdated)
+  end
+
+  def parse_time(value)
+    return nil if value.blank?
+
+    Time.parse(value.to_s).utc
+  rescue ArgumentError
+    nil
+  end
+
+  def default_reading
+    { "status" => DEFAULT_STATUS, "updated_at" => nil }
+  end
+end

--- a/app/views/dashboard/_capacity_status_toggle.html.erb
+++ b/app/views/dashboard/_capacity_status_toggle.html.erb
@@ -1,10 +1,10 @@
+<% current_status = get_capacity_status %>
 <div class="btn-group capacity-status-toggle" role="group" aria-label="Capacity Status">
   <span class="me-2 text-muted small align-self-center">Capacity Status</span>
-  <% [["capacity", "Capacity Available", "success"],
-      ["at-capacity", "At Capacity", "danger"],
-      ["has-waitlist", "Has Waitlist", "warning"],
-      ["assessment-required", "Additional Assessment Required", "info"]].each do |value, label, style| %>
-    <%= button_to label, capacity_status_path, params: { capacity_status: value }, method: :post,
-          class: "btn btn-sm #{get_capacity_status == value ? "btn-#{style}" : "btn-outline-#{style}"}" %>
+  <% CapacityStatus::STATUSES.each do |value, meta| %>
+    <% selected = current_status == value %>
+    <%= button_to meta[:label], capacity_status_path, params: { capacity_status: value }, method: :post,
+          class: "btn btn-sm #{selected ? "btn-#{meta[:style]}" : "btn-outline-#{meta[:style]}"}",
+          aria: { pressed: selected } %>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes the issue raised on CFRID-944: the dashboard does not initialize the Capacity Status toggle from the persisted FHIR value.

## Problem

`get_capacity_status` read `session[:capacity_status]`, which is empty in every new session. On a first visit, or on any new session after an update, the toggle fell back to **Capacity Available** even when the organization's `HealthcareService` held a different capacity status. The value was being written to FHIR, just never read back.

## Fix

Initialize the toggle from the `HealthcareService` capacity extension instead of the session. Reads are cached per organization for 30s so the dashboard poll does not hit the server on every request; writes prime the cache, so a change made here shows immediately.

The auto-rejection cutoff in `poll_tasks` came from the same session value, so it moves to `HealthcareService.meta.lastUpdated` for the same reason.
