### PR TITLE
Fix/compose pid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 /node_modules
 
 db/*.sqlite3
+
+# Local-only compose overrides (host port mapping, etc.)
+/docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN RAILS_ENV=production \
 EXPOSE 3000
 
 # Start the application server
-CMD ["bundle", "exec", "rails", "server", "-p", "3000"]
+CMD ["bash", "-c", "rm -f tmp/pids/server.pid && bundle exec rails server -p 3000"]
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,35 @@ rails](https://guides.rubyonrails.org/getting_started.html#creating-a-new-rails-
     environment variable: `PORT=3333 bundle exec rails s`
 * Navigate to `http://localhost:3000` in your browser
 
+## Running with Docker
+A `docker-compose.yml` is provided for running the application in a container:
+
+```
+docker compose up -d --build
+docker compose logs -f app
+```
+
+The application is served on `http://localhost:3000`.
+
+**A code change requires `--build`.** The compose file defines no bind mount, and the
+`Dockerfile` copies the source in and precompiles assets at image build time. Editing a
+file on disk therefore has no effect on a running container until the image is rebuilt:
+
+```
+docker compose up -d --build
+```
+
+To publish the application on a different host port without modifying the tracked compose
+file, create an untracked `docker-compose.override.yml` next to it. Compose reads it
+automatically and it is git-ignored:
+
+```yaml
+services:
+  app:
+    ports: !override
+      - "3001:3000"
+```
+
 ## Usage
 See [the usage
 documentation](https://github.com/Gravity-SDOHCC/sdoh_referral_source_client/blob/master/docs/usage.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # APPLICATION_HOST: "localhost:3000"
     restart: unless-stopped
     command: >
-      bash -c "bundle exec rails server -p 3000"
+      bash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3000"
 
   # redis:
   #   image: redis:alpine


### PR DESCRIPTION
## Problem

`rails server` refuses to start when `tmp/pids/server.pid` exists. Puma runs as PID 1 and
writes that file; a graceful stop removes it, but an ungraceful stop (host reboot, Docker
Desktop restart, OOM, `docker kill`) leaves it in the container's writable layer. The next
start prints `Exiting` and exits 1, and `restart: unless-stopped` retries forever — the
container never recovers without being recreated. A plain `docker restart` does not show
this, since SIGTERM lets Puma clean up after itself.

## Evidence

```
$ docker kill --signal=KILL <container>
$ docker cp <container>:/app/tmp/pids/server.pid -
1                                     # survived the kill
$ docker start <container>
$ docker ps -a
STATUS: Restarting (1) 6 seconds ago
$ docker logs --tail 2 <container>
=> Run `bin/rails server --help` for more startup options
Exiting
$ curl http://localhost:3000 → failed to connect
```

Control: a sibling client already carrying the `rm -f` guard, same SIGKILL and stale pid
file, comes back `Up` and serves HTTP 200.

## Fix

Delete the pid file before starting the server — in the compose `command`, and in the
Dockerfile `CMD` as a separate commit, since any path that runs the image directly is
exposed the same way whenever a container is restarted rather than recreated.

## Also in this PR

- **README** — a `Running with Docker` section, the key line being that **a code change
  requires `--build`**: there is no bind mount and the image bakes in the source and
  precompiled assets, so editing a file on disk has no effect on a running container.
- **`.gitignore`** — ignore `docker-compose.override.yml`, so running several RI clients
  side by side needs a local override rather than an edit to the tracked compose file. The
  tracked `3000:3000` is left alone; changing it upstream would break single-client setups.

## Verification

SIGKILL then `docker start`, twice, with the stale pid confirmed present before each start:
boots and serves 200 every time. Also clean after `docker compose down && up -d`.